### PR TITLE
GitHub Action Network Limit Removed

### DIFF
--- a/.github/workflows/geohexviz-automated-tests-conda.yml
+++ b/.github/workflows/geohexviz-automated-tests-conda.yml
@@ -13,7 +13,8 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  CACHE_NUMBER: 1  # increase to reset cache manually
+  CACHE_NUMBER: 2  # increase to reset cache manually
+  MAMBA_NO_LOW_SPEED_LIMIT: 0
 
 jobs:
   build:


### PR DESCRIPTION
The GitHub action responsible for continuous integrations using Anaconda had a network traffic timeout on it. It seems that a simple environment variable fixed it.